### PR TITLE
Db refresh performance

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[com.google.protobuf/protobuf-java "3.8.0"]
+                 [com.taoensso/tufte "2.2.0"]
                  [datascript "1.3.5"]
                  [hato "0.8.2"]
                  [manifold "0.2.3"]

--- a/src/when_is_my_ride/core.clj
+++ b/src/when_is_my_ride/core.clj
@@ -1,8 +1,9 @@
 (ns when-is-my-ride.core
   (:gen-class)
-  (:require [ring.adapter.jetty :as jetty]
-            [when-is-my-ride.server :as server]))
+  (:require [systemic.core :as systemic]
+            [when-is-my-ride.server]))
 
 (defn -main
   [& _]
-  (jetty/run-jetty (server/app) {:port 3000, :join? false, :async? true}))
+  (println "Booting app...")
+  (systemic/start!))

--- a/src/when_is_my_ride/db.clj
+++ b/src/when_is_my_ride/db.clj
@@ -52,9 +52,9 @@
   (println "Reloading DB")
   (d/future
     (let [next (new-conn)]
-    ;; TODO: parallelize
-      (mta/load-all next)
-      (nyc-ferry/load-all next)
+      @(d/zip
+        (d/future (mta/load-all next))
+        (d/future (nyc-ferry/load-all next)))
       (ds/transact! next [{:initialized-at (System/currentTimeMillis)}])
       (ds/reset-conn! conn @next)
       (println "DB refresh complete"))))
@@ -139,7 +139,7 @@
      "A")
   (q '[:find ?stop ?at
        :where
-       [?r :route/id "A"]
+       [?r :abbr "A"]
        [?ts :route ?r]
        [?ts :stop ?s]
        [?s :stop/id ?stop]

--- a/src/when_is_my_ride/db/gtfs.clj
+++ b/src/when_is_my_ride/db/gtfs.clj
@@ -1,13 +1,13 @@
 (ns when-is-my-ride.db.gtfs
   (:require [clojure.data.csv :as csv]
             [clojure.java.io :as io]
-            [datascript.core :as d]))
+            [manifold.stream :as s]))
 
 (defn id-with-prefix [prefix id]
   (when (not-empty id)
     (str prefix "-" id)))
 
-(defn feed-messages->trip-updates [feed {:keys [get-additional-fields agency conn]}]
+(defn feed-messages->trip-updates [feed {:keys [get-additional-fields agency query]}]
   (let [->id (partial id-with-prefix agency)]
     (for [i (range (.getEntityCount feed))
           :let [tu (-> feed (.getEntity i) .getTripUpdate)
@@ -15,14 +15,13 @@
                 trip-id (-> trip .getTripId ->id)
                 route-id (if (.hasRouteId trip)
                            (-> trip .getRouteId ->id)
-                           (first (d/q '[:find [?rid]
-                                         :in $ ?tid
-                                         :where
-                                         [?t :trip/id ?tid]
-                                         [?t :route ?r]
-                                         [?r :route/id ?rid]]
-                                       @conn
-                                       trip-id)))]
+                           (first (query '[:find [?rid]
+                                           :in $ ?tid
+                                           :where
+                                           [?t :trip/id ?tid]
+                                           [?t :route ?r]
+                                           [?r :route/id ?rid]]
+                                         trip-id)))]
           :when (and (some? tu) (some? trip) (< 0 (.getStopTimeUpdateCount tu)))]
       (cond-> {:agency-id agency
                :trip-id trip-id
@@ -37,7 +36,7 @@
         (some? get-additional-fields)
         (merge (get-additional-fields trip))))))
 
-(defn trip-update->datoms [{:keys [agency-id direction route-id trip-id stops]}]
+(defn trip-update->txn [{:keys [agency-id direction route-id trip-id stops]}]
   (conj
    (flatten (map
              (fn [{:keys [stop-id arrival-time ts-id]}]
@@ -61,67 +60,77 @@
    {:route/id route-id
     :agency [:agency/id agency-id]}))
 
-(defn read-stops [resource-fname agency]
-  (with-open [stop-reader (-> resource-fname io/resource io/reader)]
-    (let [->id (partial id-with-prefix agency)
-          stop-d (csv/read-csv stop-reader)
-          stop-headers (first stop-d)
-          stops (rest stop-d)
-          stop-id-idx (.indexOf stop-headers "stop_id")
-          stop-id-idx (if (= -1 stop-id-idx) 0 stop-id-idx) ; handle UTF8 signature mucking up first header
-          stop-name-idx (.indexOf stop-headers "stop_name")
-          stop-parent-idx (.indexOf stop-headers "parent_station")]
-      ;; Doall so reader can close
-      (doall
-       (map
-        (fn [stop]
-          [(let [parent (->id (get stop stop-parent-idx))]
-             (cond-> {:db/id "stop-id"
-                      :stop/id (->id (get stop stop-id-idx))
-                      :name (get stop stop-name-idx)
-                      :agency [:agency/id agency]}
-               (not-empty parent)
-               (assoc :parent [:stop/id parent])))])
-        stops)))))
+(defn- process-file [fname processor]
+  (with-open [reader (-> fname io/resource io/reader)]
+    (processor (csv/read-csv reader))))
 
-(defn read-routes [resource-fname agency]
-  (with-open [route-reader (-> resource-fname io/resource io/reader)]
-    (let [->id (partial id-with-prefix agency)
-          data (csv/read-csv route-reader)
-          headers (first data)
-          routes (rest data)
-          id-idx (.indexOf headers "route_id")
-          id-idx (if (= -1 id-idx) 0 id-idx) ; handle UTF8 signature mucking up first header
-          abbr-idx (.indexOf headers "route_short_name")
-          name-idx (.indexOf headers "route_long_name")
-          color-idx (.indexOf headers "route_color")]
+(defn read-stops [txns resource-fname agency]
+  (process-file
+   resource-fname
+   (fn [stop-d]
+     (let [->id (partial id-with-prefix agency)
+           stop-headers (first stop-d)
+           stops (rest stop-d)
+           stop-id-idx (.indexOf stop-headers "stop_id")
+           stop-id-idx (if (= -1 stop-id-idx) 0 stop-id-idx) ; handle UTF8 signature mucking up first header
+           stop-name-idx (.indexOf stop-headers "stop_name")
+           stop-parent-idx (.indexOf stop-headers "parent_station")]
       ;; Doall so reader can close
-      (doall
-       (map
-        (fn [route]
-          [{:route/id (->id (get route id-idx))
-            :abbr (get route abbr-idx)
-            :name (get route name-idx)
-            :color (get route color-idx)
-            :agency [:agency/id agency]}])
-        routes)))))
+       (doall
+        (map
+         (fn [stop]
+           (s/put! txns
+                   [(let [parent (->id (get stop stop-parent-idx))]
+                      (cond-> {:db/id "stop-id"
+                               :stop/id (->id (get stop stop-id-idx))
+                               :name (get stop stop-name-idx)
+                               :agency [:agency/id agency]}
+                        (not-empty parent)
+                        (assoc :parent [:stop/id parent])))]))
+         stops))))))
 
-(defn read-trips [resource-fname agency]
-  (with-open [route-reader (-> resource-fname io/resource io/reader)]
-    (let [->id (partial id-with-prefix agency)
-          data (csv/read-csv route-reader)
-          headers (first data)
-          trips (rest data)
-          route-id-idx (.indexOf headers "route_id")
-          route-id-idx (if (= -1 route-id-idx) 0 route-id-idx) ; handle UTF8 signature mucking up first header
-          trip-id-idx (.indexOf headers "trip_id")
-          direction-idx (.indexOf headers "direction_id")]
+(defn read-routes [txns resource-fname agency]
+  (process-file
+   resource-fname
+   (fn [data]
+     (let [->id (partial id-with-prefix agency)
+           headers (first data)
+           routes (rest data)
+           id-idx (.indexOf headers "route_id")
+           id-idx (if (= -1 id-idx) 0 id-idx) ; handle UTF8 signature mucking up first header
+           abbr-idx (.indexOf headers "route_short_name")
+           name-idx (.indexOf headers "route_long_name")
+           color-idx (.indexOf headers "route_color")]
+       ;; Doall so reader can close
+       (doall
+        (map
+         (fn [route]
+           (s/put! txns
+                   [{:route/id (->id (get route id-idx))
+                     :abbr (get route abbr-idx)
+                     :name (get route name-idx)
+                     :color (get route color-idx)
+                     :agency [:agency/id agency]}]))
+         routes))))))
+
+(defn read-trips [txns resource-fname agency]
+  (process-file
+   resource-fname
+   (fn [data]
+     (let [->id (partial id-with-prefix agency)
+           headers (first data)
+           trips (rest data)
+           route-id-idx (.indexOf headers "route_id")
+           route-id-idx (if (= -1 route-id-idx) 0 route-id-idx) ; handle UTF8 signature mucking up first header
+           trip-id-idx (.indexOf headers "trip_id")
+           direction-idx (.indexOf headers "direction_id")]
       ;; Doall so reader can close
-      (doall
-       (map
-        (fn [trip]
-          [{:trip/id (->id (get trip trip-id-idx))
-            :route [:route/id (->id (get trip route-id-idx))]
-            :direction (get trip direction-idx)
-            :agency [:agency/id agency]}])
-        trips)))))
+       (doall
+        (map
+         (fn [trip]
+           (s/put! txns
+                   [{:trip/id (->id (get trip trip-id-idx))
+                     :route [:route/id (->id (get trip route-id-idx))]
+                     :direction (get trip direction-idx)
+                     :agency [:agency/id agency]}]))
+         trips))))))

--- a/src/when_is_my_ride/db/nyc_ferry.clj
+++ b/src/when_is_my_ride/db/nyc_ferry.clj
@@ -1,44 +1,32 @@
 (ns when-is-my-ride.db.nyc-ferry
   (:import [com.google.transit.realtime GtfsRealtime$FeedMessage])
-  (:require [datascript.core :as d]
+  (:require [manifold.stream :as s]
             [hato.client :as hc]
             [when-is-my-ride.db.gtfs :as gtfs]))
 
 (def agency "nyc-ferry")
 
-(defn- load-static [conn]
-  (d/transact! conn [{:agency/id agency}])
-  (doall (map
-          (fn [datoms]
-            (d/transact! conn datoms))
-          (gtfs/read-stops "nyc-ferry/stops.txt" agency)))
-  (doall (map
-          (fn [datoms]
-            (d/transact! conn datoms))
-          (gtfs/read-routes "nyc-ferry/routes.txt" agency)))
-  (doall (map
-          (fn [datoms]
-            (d/transact! conn datoms))
-          (gtfs/read-trips "nyc-ferry/trips.txt" agency)))
-  conn)
+(defn- load-static [txns]
+  (s/put! txns [{:agency/id agency}])
+  (gtfs/read-stops txns "nyc-ferry/stops.txt" agency)
+  (gtfs/read-routes txns "nyc-ferry/routes.txt" agency)
+  (gtfs/read-trips txns "nyc-ferry/trips.txt" agency))
 
-(defn- load-trips [conn]
+(defn- load-trips [txns query]
   (doall
-   (map (fn [trip-update]
-          (d/transact! conn (gtfs/trip-update->datoms trip-update)))
+   (map #(->> % gtfs/trip-update->txn (s/put! txns))
         (-> (hc/get
              "http://nycferry.connexionz.net/rtt/public/utility/gtfsrealtime.aspx/tripupdate"
              {:as :byte-array})
             :body
             GtfsRealtime$FeedMessage/parseFrom
-            (gtfs/feed-messages->trip-updates {:agency agency :conn conn}))))
-  conn)
+            (gtfs/feed-messages->trip-updates {:agency agency :query query})))))
 
-(defn load-all [conn]
+(defn load-all [txns query]
   (println "Loading NYC Ferry data")
-  (let [res (-> conn load-static load-trips)]
-    (println "Done loading NYC Ferry data")
-    res))
+  (load-static txns)
+  (load-trips txns query)
+  (println "Done loading NYC Ferry data"))
 
 (comment
   (-> (hc/get

--- a/src/when_is_my_ride/db/nyc_ferry.clj
+++ b/src/when_is_my_ride/db/nyc_ferry.clj
@@ -35,7 +35,10 @@
   conn)
 
 (defn load-all [conn]
-  (-> conn load-static load-trips))
+  (println "Loading NYC Ferry data")
+  (let [res (-> conn load-static load-trips)]
+    (println "Done loading NYC Ferry data")
+    res))
 
 (comment
   (-> (hc/get

--- a/src/when_is_my_ride/perf.clj
+++ b/src/when_is_my_ride/perf.clj
@@ -1,0 +1,24 @@
+(ns when-is-my-ride.perf
+  (:require [systemic.core :refer [defsys]]
+            [taoensso.tufte :as tufte]
+            [when-is-my-ride.env :refer [env]]))
+
+(def LOG_INTERVAL 10000)
+
+(defonce stats-acc
+  (tufte/add-accumulating-handler! {:ns-pattern "*"}))
+
+(defn do-every [ms f]
+  (future (while true (do (Thread/sleep ms)
+                          (f)))))
+
+(defn log-perf-stats []
+  (when-let [stats (not-empty @stats-acc)]
+    (println (tufte/format-grouped-pstats stats))))
+
+(defsys *perf* []
+  :closure
+  (let [enabled? (env "LOG_PERF")
+        logger (when enabled? (do-every LOG_INTERVAL log-perf-stats))]
+    {:value logger
+     :stop #(when logger (future-cancel logger))}))

--- a/src/when_is_my_ride/server.clj
+++ b/src/when_is_my_ride/server.clj
@@ -1,5 +1,6 @@
 (ns when-is-my-ride.server
-  (:require [reitit.http :as http]
+  (:require [clojure.java.io :as io]
+            [reitit.http :as http]
             [reitit.ring :as ring]
             [reitit.http.interceptors.parameters :as parameters]
             [reitit.interceptor.sieppari]
@@ -7,10 +8,13 @@
             [ring.adapter.jetty :as jetty]
             [muuntaja.interceptor]
             [systemic.core :as systemic :refer [defsys]]
+            [taoensso.tufte :as tufte]
             [when-is-my-ride.api :as api]
             [when-is-my-ride.cors :as cors]
             [when-is-my-ride.env :refer [env]]
-            [clojure.java.io :as io]))
+            [when-is-my-ride.perf :refer [*perf*]]))
+
+
 
 (defn app []
   (http/ring-handler
@@ -20,9 +24,17 @@
                      (cors/interceptor {:access-control-allow-origin [(re-pattern (env "ALLOW_ORIGIN"))]
                                         :access-control-allow-methods [:get :put :post :delete]})]}
      ["/stops"
-      ["" {:get {:interceptors [{:leave (fn [& args] (apply api/stops-handler args))}]}}]
+      ["" {:get {:interceptors [{:leave
+                                 (fn [& args]
+                                   (tufte/profile {:id "stops"
+                                                   :dynamic? true}
+                                                  (apply api/stops-handler args)))}]}}]
       ["/:stop-id"
-       {:get {:interceptors [{:leave (fn [& args] (apply api/stop-handler args))}]}}]]])
+       {:get {:interceptors [{:leave
+                              (fn [& args]
+                                (tufte/profile {:id "arrivals"
+                                                :dynamic? true}
+                                               (apply api/stop-handler args)))}]}}]]])
    (ring/routes
     (ring/create-resource-handler {:path "/"})
     (ring/create-default-handler
@@ -36,6 +48,7 @@
     :interceptors [(muuntaja.interceptor/format-interceptor)]}))
 
 (defsys *server* []
+  :deps [*perf*]
   :closure
   (let [server (jetty/run-jetty (app) {:port 3000, :join? false, :async? true})]
     {:value server


### PR DESCRIPTION
This appears to work. Got it a bit faster I hope.

Some use-case aware future work:

- Allow GET /stops requests to use a stale db (as it is uncommon -- though possible -- for trip updates to alter trains for a given stop)
- Preemptively refresh database every X seconds for Y minutes after an API request, effectively keeping the db "warm" under active use. Decreases the likelihood of needing to block a request on a refresh
- Further profile the refresh-db callstack, seeking areas to improve performance